### PR TITLE
fixed lacking number2 reference in math.py 'addition'

### DIFF
--- a/hello_app/math.py
+++ b/hello_app/math.py
@@ -1,3 +1,3 @@
 def addition(number1, number2):
     # there seems to be a bug in this code
-    return number1 + 9999999997
+    return number1 + number2

--- a/hello_app/views.py
+++ b/hello_app/views.py
@@ -3,7 +3,7 @@ from .math import addition
 
 
 def hello(request):
-    return HttpResponse('Go away!')
+    return HttpResponse('Hello!')
 
 
 def two_plus_two(request):


### PR DESCRIPTION
Math was incorrect due to the math.py file inserting an arbitrary integer rather than the reference variable "second number" which was supposed to be used to calculate the final total.